### PR TITLE
Allow search of users via multiple fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,23 @@ Retrieves the basic details about the walks owned by a user, given a user ID.
   - **400 Bad Request** – userID not of type ObjectID
   
 ---
+
+#### Search for users
+
+```
+GET /users/search/:userInfo
+```
+
+Returns a list of users matching the information provided (which could be a username, email or name).
+
+- Required Parameters:
+  - **userInfo** _(String)_
+
+- Success response:
+  - Code: 200 OK
+  - Content: A success flag and an array containing the matched users
+  
+- Errors:
+  - **400 Bad Request** – database validation error
+  
+---

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -24,3 +24,7 @@ module.exports.getWalks = function(req, res, next) {
     });
   });
 };
+
+module.exports.search = function(req, res, next) {
+  
+};

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -35,19 +35,18 @@ module.exports.search = function(req, res, next) {
     names[key] = new RegExp('^' + fullNameTerms[key] + '$', 'i');
   }
 
-  console.log(userInfo);
   User.find({$or:[{username: userInfo}, {'name.firstName': userInfo}, {'name.lastName': userInfo}, {email: userInfo},
-            {$and: [{'name.firstName': names[0]}, {'name.lastName': names[1]}]}]}, function(error, user) {
+            {$and: [{'name.firstName': names[0]}, {'name.lastName': names[1]}]}]}, function(error, users) {
     if (error) return helper.mongooseValidationError(error, res);
 
-    if (user.length == 0) return res.status(404).json({
+    if (users.length == 0) return res.status(404).json({
                             success: false,
                             error: 'No users could be found.'
                           });
 
     res.status(200).json({
       success: true,
-      user: user
+      users: users
     })
   });
 };

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -41,11 +41,23 @@ module.exports.search = function(req, res, next) {
             function(error, users) {
     if (error) return helper.mongooseValidationError(error, res);
 
+    var userDetails = [];
 
+    users.forEach(function(user) {
+      userDetails.push({
+        id: user._id,
+        username: user.username,
+        email: user.email,
+        name: {
+          firstName: user.name.firstName,
+          lastName: user.name.lastName
+        }
+      });
+    });
 
     res.status(200).json({
       success: true,
-      users: users
+      users: userDetails
     })
   });
 };

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -28,14 +28,22 @@ module.exports.getWalks = function(req, res, next) {
 
 module.exports.search = function(req, res, next) {
   var userInfo = new RegExp('^' + req.params.userInfo + '$', 'i');
-  
-  User.findOne({$or:[{'username': userInfo}, {'name.firstName': userInfo}, {'name.lastName': userInfo}]}, function(error, user) {
+  var fullNameTerms = req.params.userInfo.split(' ');
+  var names = [];
+
+  for (let key in fullNameTerms) {
+    names[key] = new RegExp('^' + fullNameTerms[key] + '$', 'i');
+  }
+
+  console.log(userInfo);
+  User.find({$or:[{username: userInfo}, {'name.firstName': userInfo}, {'name.lastName': userInfo}, {email: userInfo},
+            {$and: [{'name.firstName': names[0]}, {'name.lastName': names[1]}]}]}, function(error, user) {
     if (error) return helper.mongooseValidationError(error, res);
 
-    if (!user) return res.status(404).json({
-                        success: false,
-                        error: 'No users could be found.'
-                      });
+    if (user.length == 0) return res.status(404).json({
+                            success: false,
+                            error: 'No users could be found.'
+                          });
 
     res.status(200).json({
       success: true,

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -1,4 +1,5 @@
 const Walk = require('../models/walk'),
+      User = require('../models/user'),
       helper = require('./helper');
 
 module.exports.getWalks = function(req, res, next) {
@@ -26,5 +27,19 @@ module.exports.getWalks = function(req, res, next) {
 };
 
 module.exports.search = function(req, res, next) {
+  var userInfo = new RegExp('^' + req.params.userInfo + '$', 'i');
   
+  User.findOne({$or:[{'username': userInfo}, {'name.firstName': userInfo}, {'name.lastName': userInfo}]}, function(error, user) {
+    if (error) return helper.mongooseValidationError(error, res);
+
+    if (!user) return res.status(404).json({
+                        success: false,
+                        error: 'No users could be found.'
+                      });
+
+    res.status(200).json({
+      success: true,
+      user: user
+    })
+  });
 };

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -35,14 +35,13 @@ module.exports.search = function(req, res, next) {
     names[key] = new RegExp('^' + fullNameTerms[key] + '$', 'i');
   }
 
-  User.find({$or:[{username: userInfo}, {'name.firstName': userInfo}, {'name.lastName': userInfo}, {email: userInfo},
-            {$and: [{'name.firstName': names[0]}, {'name.lastName': names[1]}]}]}, function(error, users) {
+  User.find({$or:[{username: userInfo}, {'name.firstName': userInfo}, 
+            {'name.lastName': userInfo}, {email: userInfo},
+            {$and: [{'name.firstName': names[0]}, {'name.lastName': names[1]}]}]}, 
+            function(error, users) {
     if (error) return helper.mongooseValidationError(error, res);
 
-    if (users.length == 0) return res.status(404).json({
-                            success: false,
-                            error: 'No users could be found.'
-                          });
+
 
     res.status(200).json({
       success: true,

--- a/routes/users.js
+++ b/routes/users.js
@@ -4,5 +4,6 @@ const express = require('express'),
       helper = require('./helper');
 
 usersRouter.get('/:userID/walks', helper.jwtAuth, users.getWalks);
+usersRouter.get('/search/:userID', users.search);
 
 module.exports = usersRouter;

--- a/routes/users.js
+++ b/routes/users.js
@@ -4,6 +4,6 @@ const express = require('express'),
       helper = require('./helper');
 
 usersRouter.get('/:userID/walks', helper.jwtAuth, users.getWalks);
-usersRouter.get('/search/:userID', users.search);
+usersRouter.get('/search/:userInfo', users.search);
 
 module.exports = usersRouter;

--- a/test/users_test.js
+++ b/test/users_test.js
@@ -17,13 +17,19 @@ var jwt,
       steps: 23590248950
     };
 
+var username = 'bob1234',
+    email = 'bob@bobson.com',
+    password = 'amble4lyfe',
+    firstName = 'Bob',
+    lastName = 'Bobson'
+
 describe('GET /:userID/walks', function() {
 
   before(function(done) {
     request(app)
       .post('/api/auth/register')
-      .send({username: 'bob1234', email: 'bob@bobson.com', 
-        password: 'amble4lyfe', firstName: 'Bob', lastName: 'Bobson'})
+      .send({username: username, email: email, 
+        password: password, firstName: firstName, lastName: lastName})
       .end(function(err, res) {
         if (err) return done(err);
         jwt = res.body.jwt;
@@ -85,7 +91,87 @@ describe('GET /:userID/walks', function() {
 
   // Clear database
   after(function(done) {
-    helper.clearDB('users');
     helper.clearDB('walks', done);
+  });
+});
+
+describe('GET /search/:userInfo', function() {
+  describe('Valid user search', function () {
+    it('should return user when searching with valid username', function(done) {
+      request(app)
+        .get(uriPrefix + '/search/' + username)
+        .expect('Content-Type', /json/)
+        .expect(function(res) {
+          res.body.success.should.be.equal(true);
+          res.body.users.should.have.length(1);
+          res.body.users[0].username.should.be.equal(username);
+        })
+        .expect(200, done);
+    });
+
+    it('should return user when searching with valid email', function(done) {
+      request(app)
+        .get(uriPrefix + '/search/' + email)
+        .expect('Content-Type', /json/)
+        .expect(function(res) {
+          res.body.success.should.be.equal(true);
+          res.body.users.should.have.length(1);
+          res.body.users[0].username.should.be.equal(username);
+        })
+        .expect(200, done);
+    });
+
+    it('should return user when searching with valid first name', function(done) {
+      request(app)
+        .get(uriPrefix + '/search/' + firstName)
+        .expect('Content-Type', /json/)
+        .expect(function(res) {
+          res.body.success.should.be.equal(true);
+          res.body.users.should.have.length(1);
+          res.body.users[0].username.should.be.equal(username);
+        })
+        .expect(200, done);
+    });
+
+    it('should return user when searching with valid last name', function(done) {
+      request(app)
+        .get(uriPrefix + '/search/' + lastName)
+        .expect('Content-Type', /json/)
+        .expect(function(res) {
+          res.body.success.should.be.equal(true);
+          res.body.users.should.have.length(1);
+          res.body.users[0].username.should.be.equal(username);
+        })
+        .expect(200, done);
+    });
+
+    it('should return user when searching with valid full name', function(done) {
+      request(app)
+        .get(uriPrefix + '/search/' + firstName + ' ' + lastName)
+        .expect('Content-Type', /json/)
+        .expect(function(res) {
+          res.body.success.should.be.equal(true);
+          res.body.users.should.have.length(1);
+          res.body.users[0].username.should.be.equal(username);
+        })
+        .expect(200, done);
+    });
+  });
+
+  describe('Invalid user search', function() {
+    it('should return error with username not found', function(done) {
+      request(app)
+        .get(uriPrefix + '/search/invalid_username')
+        .expect('Content-Type', /json/)
+        .expect(function(res) {
+          res.body.success.should.be.equal(false);
+          res.body.error.should.be.equal('No users could be found.');
+        })
+        .expect(200, done);
+    });
+  });
+
+  after(function(done) {
+    helper.clearDB('users', done);
   });
 });

--- a/test/users_test.js
+++ b/test/users_test.js
@@ -164,8 +164,8 @@ describe('GET /search/:userInfo', function() {
         .get(uriPrefix + '/search/invalid_username')
         .expect('Content-Type', /json/)
         .expect(function(res) {
-          res.body.success.should.be.equal(false);
-          res.body.error.should.be.equal('No users could be found.');
+          res.body.success.should.be.equal(true);
+          res.body.users.should.have.length(0);
         })
         .expect(200, done);
     });

--- a/test/users_test.js
+++ b/test/users_test.js
@@ -133,9 +133,9 @@ describe('GET /search/:userInfo', function() {
         .expect(200, done);
     });
 
-    it('should return user when searching with valid last name', function(done) {
+    it('should return user when searching with valid last name (case insensitive)', function(done) {
       request(app)
-        .get(uriPrefix + '/search/' + lastName)
+        .get(uriPrefix + '/search/' + lastName.toUpperCase())
         .expect('Content-Type', /json/)
         .expect(function(res) {
           res.body.success.should.be.equal(true);
@@ -156,12 +156,21 @@ describe('GET /search/:userInfo', function() {
         })
         .expect(200, done);
     });
-  });
 
-  describe('Invalid user search', function() {
-    it('should return empty array with ', function(done) {
+    it('should return empty array with username not found', function(done) {
       request(app)
         .get(uriPrefix + '/search/invalid_username')
+        .expect('Content-Type', /json/)
+        .expect(function(res) {
+          res.body.success.should.be.equal(true);
+          res.body.users.should.have.length(0);
+        })
+        .expect(200, done);
+    });
+
+    it('should return empty array with name not found', function(done) {
+      request(app)
+        .get(uriPrefix + '/search/invalid name')
         .expect('Content-Type', /json/)
         .expect(function(res) {
           res.body.success.should.be.equal(true);

--- a/test/users_test.js
+++ b/test/users_test.js
@@ -159,7 +159,7 @@ describe('GET /search/:userInfo', function() {
   });
 
   describe('Invalid user search', function() {
-    it('should return error with username not found', function(done) {
+    it('should return empty array with ', function(done) {
       request(app)
         .get(uriPrefix + '/search/invalid_username')
         .expect('Content-Type', /json/)


### PR DESCRIPTION
- Endpoint created to search for users – GET /users/search/:userID
- Users can be searched for via username, email, first name, last name or full name
- Returns a list of users that matched the query, or an empty array if no users were found