### PR TITLE
Obtain user ID through JWT authentication to prevent unwanted account changes

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -121,7 +121,7 @@ module.exports.invite = function(req, res, next) {
                       })
 
     var invite = new Invite({
-      from: req.body.from,
+      from: req.user._id,
       to: userID,
       date: date
     });

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -91,7 +91,7 @@ module.exports.search = function(req, res, next) {
 };
 
 module.exports.registerToken = function(req, res, next) {
-  User.findByIdAndUpdate(req.params.userID, {deviceToken: req.params.token}, {new: true}, function(error, user) {
+  User.findByIdAndUpdate(req.user._id, {deviceToken: req.params.token}, {new: true}, function(error, user) {
     if (error) return helper.mongooseValidationError(error, res);
 
     if (!user) return res.status(404).json({

--- a/documentation/users/invite.md
+++ b/documentation/users/invite.md
@@ -18,6 +18,7 @@ Sends an invite to a user given their ID and sends a push notification to their 
 ### Parameters
 
 - **userID**: ObjectID _(required)_
+- **date**: String _(required)_
 
 ### Success response
 

--- a/documentation/users/register_token.md
+++ b/documentation/users/register_token.md
@@ -3,7 +3,7 @@
 ## Register iOS device token
 
 ```
-GET /users/:userID/register/:token
+GET /users/register/:token
 ```
 
 ### Description
@@ -12,7 +12,6 @@ Registers or updates a device token for a user, given their user ID.
 
 ### Parameters
 
-- **userID**: ObjectID _(required)_
 - **token**: String _(required)_
 
 ### Success response

--- a/routes/helper.js
+++ b/routes/helper.js
@@ -4,11 +4,15 @@ const passport = require('passport'),
 module.exports.jwtAuth = function(req, res, next) {
   passport.authenticate('jwt', config.jwtSession, function(error, user, info) {
     if (error) return next(error);
+
     var message = info ? info.message : "Invalid token";
+
     if (!user) return res.status(401).json({
                     success: false,
                     error: message
                   })
+
+    req.user = user;
     next();
   })(req, res, next);
 };

--- a/routes/users.js
+++ b/routes/users.js
@@ -6,7 +6,7 @@ const express = require('express'),
 usersRouter.get('/:userID', helper.jwtAuth, users.getInfo);
 usersRouter.get('/:userID/walks', helper.jwtAuth, users.getWalks);
 usersRouter.get('/search/:userInfo', users.search);
-usersRouter.get('/:userID/register/:token', helper.jwtAuth, users.registerToken);
+usersRouter.get('/register/:token', helper.jwtAuth, users.registerToken);
 usersRouter.post('/invite/:userID', helper.jwtAuth, users.invite);
 
 module.exports = usersRouter;

--- a/test/users_test.js
+++ b/test/users_test.js
@@ -234,7 +234,7 @@ describe('GET /:userID/register/:token', function() {
   describe('Valid token registration', function() {
     it('should succeed with valid user ID and valid token', function(done) {
       request(app)
-        .get(uriPrefix + '/' + userID + '/register/' + deviceToken)
+        .get(uriPrefix + '/register/' + deviceToken)
         .set('Authorization', 'JWT ' + jwt)
         .expect('Content-Type', /json/)
         .expect(function(res) {
@@ -242,33 +242,6 @@ describe('GET /:userID/register/:token', function() {
           res.body.user.deviceToken.should.be.equal(deviceToken);
         })
         .expect(200, done);
-    });
-  });
-
-  describe('Invalid device registration', function() {
-    it('should return error with invalid user ID', function(done) {
-      request(app)
-        .get(uriPrefix + '/' + invalidID + '/register/' + deviceToken)
-        .set('Authorization', 'JWT ' + jwt)
-        .expect('Content-Type', /json/)
-        .expect(function(res) {
-          res.body.success.should.be.equal(false);
-          res.body.error.should.be.equal('Cast to ObjectId failed for value "' 
-            + invalidID + '" at path "_id" for model "User"');
-        })
-        .expect(400, done);
-    });
-
-    it('should return error with user ID not found', function(done) {
-      request(app)
-        .get(uriPrefix + '/' + notFoundID + '/register/' + deviceToken)
-        .set('Authorization', 'JWT ' + jwt)
-        .expect('Content-Type', /json/)
-        .expect(function(res) {
-          res.body.success.should.be.equal(false);
-          res.body.error.should.be.equal('User does not exist.');
-        })
-        .expect(404, done);
     });
   });
 });
@@ -279,7 +252,7 @@ describe('POST /invite/:userID', function() {
       request(app)
         .post(uriPrefix + '/invite/' + userID)
         .set('Authorization', 'JWT ' + jwt)
-        .send({from: notFoundID, date: '01/01/70'})
+        .send({date: '01/01/70'})
         .expect('Content-Type', /json/)
         .expect(function(res) {
           res.body.success.should.be.equal(true);


### PR DESCRIPTION
- Some endpoints (invite, registerToken) required the user's ID to update a value, which meant that someone could update another user's value
- User ID is now obtained through JWT authentication